### PR TITLE
Added GitHub Actions build badge and link to the online lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Website
+[![.github/workflows/deploy.yml](https://github.com/mongodb-developer/search-play-workshop/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/mongodb-developer/search-play-workshop/actions/workflows/deploy.yml)
+
+# Atlas Search Fundamentals
+
+You can access the online version on the Intro Lab [here](https://mongodb-developer.github.io/search-play-workshop/)
+
+### Website
 
 This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 


### PR DESCRIPTION
This PR adds a nice GH Actions build passing / failed badge and a direct link to the online lab here: https://mongodb-developer.github.io/search-play-workshop/